### PR TITLE
Permission error when creating temp dir

### DIFF
--- a/msf/msf_tmp_path.m
+++ b/msf/msf_tmp_path.m
@@ -6,7 +6,8 @@ function tmp_path = msf_tmp_path(do_mkdir)
 if (nargin < 1), do_mkdir = 1; end
 
 % Create a unique temporary directory name to make the code thread safe.
-tmp_path = fullfile(tempdir, 'mdm', char(java.util.UUID.randomUUID));
+% tmp_path = fullfile(tempdir, 'mdm', char(java.util.UUID.randomUUID)); % may result in permission denied when mkdir
+tmp_path = fullfile(tempdir, ['mdm_' char(java.util.UUID.randomUUID)]);
 
 if (do_mkdir)
     msf_mkdir(tmp_path);


### PR DESCRIPTION
https://github.com/markus-nilsson/md-dmri/blob/0ea711da7fcceecccab4ece6553cc3eca1e107e3/msf/msf_tmp_path.m#L9

This might be problematic when multiple users are using this code. Once the first user creates a temp folder `/tmp/mdm/randomID1`, other users cannot create a new folder under `/tmp/mdm/`.